### PR TITLE
Bug fix to the cookie consent option

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,8 +10,6 @@ website:
   image: images/bp-logo.png
   page-footer:
     background: light
-  cookie-consent:
-    type: false
 
   page-navigation: true
   navbar:


### PR DESCRIPTION
Apparently you have to delete it for it not to show. I got the impression from the documentation that it was possible to put `false` there but re-reading it that's not one of the options:

https://quarto.org/docs/websites/website-tools.html#cookie-consent