### PR TITLE
Documentation/download

### DIFF
--- a/datasets/download/downloading-data.qmd
+++ b/datasets/download/downloading-data.qmd
@@ -5,9 +5,9 @@ title: Download guide
 This section provides guidelines on the necessary steps to download data from BigPicture.
 
 ## Get access to a dataset
-The first step for downloading data from Big Picture is to get access to the dataset the user is interested in. This can be done by visiting REMS [here](https://bp-rems.sd.csc.fi/).
+The first step to download data from Big Picture is to get access to the dataset the user is interested in. This can be done by visiting REMS [here](https://bp-rems.sd.csc.fi/).
 Log in, choose the datasets of interest and add them to the cart. After that, the user can apply for access, fill in the form and send the application.
-The user needs to wait for approval from the data access committee (DAC) and after it is approved the user can download the datasets.
+The user needs to wait for approval from the data access committee (DAC) and after it has been approved the user can download the datasets.
 
 ## Preparation for downloading data
 
@@ -25,15 +25,15 @@ The initial step involves creating a crypt4gh keypair using the sda-cli:
 ./sda-cli createKey <keypair_name>
 ```
 
-where `<keypair_name>` is the base name of the key files. The above command will create two keys files named
+where `<keypair_name>` is the base name of the key files. The above command will create two key files named
 `keypair_name.pub.pem` and `keypair_name.sec.pem`. The public key (`pub`) will be sent to the admins
-and will be used by the system for encryption of the files before download, while the private one
+and will be used by the system for encryption of the files before downloading, while the private one
 (`sec`) will be used by the requester for decrypting the files after downloading.
 
 ## Check access
 
-After the user has been granted access to the dataset, the user can check the access to the dataset by listing the datasets and their files using the sda-cli.
-This can be done by following the instructions in the sda-cli documentation in the `List datasets and their files` section [here](https://github.com/NBISweden/sda-cli#list-datasets-and-their-files).
+After the user has been granted access to the dataset, the user can check access to the dataset by listing the datasets and their files using the `sda-cli`.
+This can be done by following the instructions in the `List datasets and their files` section of the `sda-cli` documentation [here](https://github.com/NBISweden/sda-cli#list-datasets-and-their-files).
 
 ## Download data
 
@@ -43,7 +43,7 @@ After having acquired access to the datasets, the configuration file and the sda
     - using filepaths
     - using file IDs
     - recursively downloading all files in a folder
-    - downloading files by providint a text file with the paths of the files to download
+    - downloading files by providing a text file with the paths of the files to download
     - download all the files of the dataset
 
 - Encrypted files:


### PR DESCRIPTION
With this PR, the instructions for the download part are updated so that the user can directly use the download service instead of following the publicizing procedure.

Closes #16 