### PR TITLE
Make the email more clear in the submission guide

### DIFF
--- a/datasets/submission/submission-guide.qmd
+++ b/datasets/submission/submission-guide.qmd
@@ -237,7 +237,7 @@ Once your files are encrypted, you are ready to start uploading them.
 
 ## Notify us {#notify-us}
 
-Once your submission is completed, please don't forget to notify us by [sending an email](mailto:{{< var email.helpdesk >}}). The email should contain
+Once your submission is completed, please don't forget to notify us by sending an email to [{{<var email.helpdesk>}}](mailto:{{< var email.helpdesk >}}). The email should contain
 
 - Name of the uploader 
 - Name of the dataset 


### PR DESCRIPTION
The email address was behind a link that did not make it clear it was a link to an email address.