### PR TITLE
Fix url for the grafana dashboard

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -52,4 +52,4 @@ AI training - Guidance on how to procure on-platform GPU HPC resources
 ### Metrics 
 [Numbers from the repository](https://bp.nbis.se/metrics/)
 
-[Archive status](https:/grafana.bp.nbis.se/public-dashboards/c465fe145d7844b59d7eea87be8e199d){target="_blank"}
+[Archive status](https://grafana.bp.nbis.se/public-dashboards/c465fe145d7844b59d7eea87be8e199d){target="_blank"}


### PR DESCRIPTION
This PR closes #46 

**How to test**
Go to https://bp.nbis.se/, click the link `Archive status` at the bottom of the page, and it's broken.
The broken link will be fixed after merging.