### PR TITLE
docs: add changelog for 2026-06-01

### DIFF
--- a/changelogs/changelog-2026-06-01.qmd
+++ b/changelogs/changelog-2026-06-01.qmd
@@ -67,4 +67,4 @@ toc: false
 * New multiple storage backends library. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2162
   * Fix bug in library to support TLS. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2217
 * Fix linter issues across multiple services. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2257
-
+* Add RotateKey service documentation to the sda documentation. By @jBygdell in https://github.com/neicnordic/sensitive-data-archive/pull/2288

--- a/changelogs/changelog-2026-06-01.qmd
+++ b/changelogs/changelog-2026-06-01.qmd
@@ -22,6 +22,7 @@ toc: false
 * Fix code lint issues. By @jBygdell in https://github.com/neicnordic/sensitive-data-archive/pull/2179
 * Enable Htsget-rs functionalities
     * Support Htsget-Context-Public-Key header. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2226
+* Fix possible issue with downloading bigger files(>1gb). By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2402
 
 ## Download v2
 

--- a/changelogs/changelog-2026-06-01.qmd
+++ b/changelogs/changelog-2026-06-01.qmd
@@ -1,0 +1,70 @@
+---
+pagetitle: BigPicture Changelog 2026-06-01
+sidebar: false
+toc: false
+---
+
+# Detailed Changelog 2026-06-01
+
+## Admin-API
+
+* Add new command for key rotation. By @pahatz in https://github.com/neicnordic/sensitive-data-archive/pull/2058
+
+## API
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+
+## Download
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+* Return 403 if user attempts to download non-existing data or data which user does not have access to. By @nanjiangshu in https://github.com/neicnordic/sensitive-data-archive/pull/2317
+    * Previously returned a List of the datasets user had access to when such was attempted.
+* Fix code lint issues. By @jBygdell in https://github.com/neicnordic/sensitive-data-archive/pull/2179
+* Enable Htsget-rs functionalities
+    * Support Htsget-Context-Public-Key header. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2226
+
+## Download v2
+
+* New download-v2 API specification. By @jhagberg in https://github.com/neicnordic/sensitive-data-archive/pull/2232
+* New download-v2 API implementation. By @jhagberg in https://github.com/neicnordic/sensitive-data-archive/pull/2187
+
+## Finalize
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+    * Bugfix populate backup location and path. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2342
+
+## Ingest
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+
+## Mapper
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+
+## RotateKey
+
+* New admin service to support rotating private key used to encrypt a dataset. By @aaperis in https://github.com/neicnordic/sensitive-data-archive/pull/1918
+* Add backup of headers before rotating of key. By @nanjiangshu in https://github.com/neicnordic/sensitive-data-archive/pull/2164
+
+## S3Inbox
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+* Use postgres instead of in memory cache for file multi part uploads. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2382
+    * More strict S3 action detection, supported S3 actions are: GetBucketLocation, ListObjects, ListObjectsV2, PutObject, UploadPart, CreateMultiPartUpload, CompleteMultiPartUpload, AbortMultiPartUpload, ListMultiPartUpload, ListParts
+    * Return generic error messages on errors
+
+## Sync
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+
+## Verify
+
+* Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+
+## Common
+
+* Update Go to version 1.25. By @jBygdell in https://github.com/neicnordic/sensitive-data-archive/pull/2276
+* New multiple storage backends library. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2162
+  * Fix bug in library to support TLS. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2217
+* Fix linter issues across multiple services. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2257
+


### PR DESCRIPTION
Add changelog for the planned 2026-06-01 deployment during maintenence window

Derived from
``` 
git log --pretty=oneline v3.1.0..v3.1.57 | grep "Merge pull request" | grep -v "dependabot" | grep -v "bump" 
``` 
And extracting relevant PRs

Plus https://github.com/neicnordic/sensitive-data-archive/pull/1918 for the rotate key service

Currently excluded PRs related to integration tests, github actions workflow, docs, charts, etc.
