### PR TITLE
docs/2026-06-01 changelong amendment, disable syncing to CSC and instead backup on 2nd location on our side

### DIFF
--- a/changelogs/changelog-2026-06-01.qmd
+++ b/changelogs/changelog-2026-06-01.qmd
@@ -57,6 +57,8 @@ toc: false
 ## Sync
 
 * Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
+* Temporarily disable syncing files to CSC as the sda-stack is no longer compatible with the older CEPH version running on the CSC side, instead will backup files to a second location on the NBIS side
+  * Once CSC confirms they have updated the CEPH version running on their side we will plan on enabling syncing to CSC again, including backporting the syncing of all files backup to the second location on the NBIS side since this release
 
 ## Verify
 

--- a/changelogs/changelog-2026-06-01.qmd
+++ b/changelogs/changelog-2026-06-01.qmd
@@ -57,8 +57,8 @@ toc: false
 ## Sync
 
 * Multiple storage backends support. By @KarlG-nbis in https://github.com/neicnordic/sensitive-data-archive/pull/2244
-* Temporarily disable syncing files to CSC as the sda-stack is no longer compatible with the older CEPH version running on the CSC side, instead will backup files to a second location on the NBIS side
-  * Once CSC confirms they have updated the CEPH version running on their side we will plan on enabling syncing to CSC again, including backporting the syncing of all files backup to the second location on the NBIS side since this release
+* Temporarily disable syncing files to CSC as the sda-stack is no longer compatible with the older CEPH version running on the CSC side, and instead back up files to a second location on the NBIS side
+  * Once CSC confirms they have updated the CEPH version running on their side, we will plan on enabling syncing to CSC again, including backporting the syncing of all files backed up to the second location on the NBIS side since this release
 
 ## Verify
 


### PR DESCRIPTION
add amendment to 2026-06-01 changelog mentioning disabling syniing to CSC and instead backing up to 2nd location on our side