### PR TITLE
Update metrics endpoint URL

### DIFF
--- a/metrics/index.qmd
+++ b/metrics/index.qmd
@@ -25,7 +25,7 @@ format:
 
 <script>
 (async () => {
-  const JSON_URL = "https://data.metrics.bp.nbis.se/metrics.json";
+  const JSON_URL = "https://metrics.bp.nbis.se/metrics.json";
   const root = document.getElementById("metrics-root");
 
   const METRICS = [


### PR DESCRIPTION
Updates the metrics.json endpoint URL in the metrics page.

- Changed from `https://data.metrics.bp.nbis.se/metrics.json` to `https://metrics.bp.nbis.se/metrics.json`